### PR TITLE
Fix: Use relative paths for all navigation links

### DIFF
--- a/contato/index.html
+++ b/contato/index.html
@@ -27,7 +27,7 @@
     <!-- A. Cabeçalho -->
     <header>
         <div class="container">
-            <a href="/" class="logo">Pro Solo</a>
+            <a href="../" class="logo">Pro Solo</a>
             <nav>
                 <button class="hamburger" id="hamburger-menu">
                     <span></span>
@@ -35,10 +35,10 @@
                     <span></span>
                 </button>
                 <ul id="nav-links">
-                    <li><a href="/">INÍCIO</a></li>
-                    <li><a href="/quem-somos/">QUEM SOMOS</a></li>
-                    <li><a href="/organic/">ORGANIC</a></li>
-                    <li><a href="/contato/">FALE CONOSCO</a></li>
+                    <li><a href="../">INÍCIO</a></li>
+                    <li><a href="../quem-somos/">QUEM SOMOS</a></li>
+                    <li><a href="../organic/">ORGANIC</a></li>
+                    <li><a href=".">FALE CONOSCO</a></li>
                 </ul>
             </nav>
         </div>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <!-- A. Cabeçalho -->
     <header>
         <div class="container">
-            <a href="/" class="logo">Pro Solo</a>
+            <a href="." class="logo">Pro Solo</a>
             <nav>
                 <button class="hamburger" id="hamburger-menu">
                     <span></span>
@@ -23,10 +23,10 @@
                     <span></span>
                 </button>
                 <ul id="nav-links">
-                    <li><a href="/">INÍCIO</a></li>
-                    <li><a href="/quem-somos/">QUEM SOMOS</a></li>
-                    <li><a href="/organic/">ORGANIC</a></li>
-                    <li><a href="/contato/">FALE CONOSCO</a></li>
+                    <li><a href=".">INÍCIO</a></li>
+                    <li><a href="quem-somos/">QUEM SOMOS</a></li>
+                    <li><a href="organic/">ORGANIC</a></li>
+                    <li><a href="contato/">FALE CONOSCO</a></li>
                 </ul>
             </nav>
         </div>

--- a/organic/index.html
+++ b/organic/index.html
@@ -15,7 +15,7 @@
     <!-- A. Cabeçalho -->
     <header>
         <div class="container">
-            <a href="/" class="logo">Pro Solo</a>
+            <a href="../" class="logo">Pro Solo</a>
             <nav>
                 <button class="hamburger" id="hamburger-menu">
                     <span></span>
@@ -23,10 +23,10 @@
                     <span></span>
                 </button>
                 <ul id="nav-links">
-                    <li><a href="/">INÍCIO</a></li>
-                    <li><a href="/quem-somos/">QUEM SOMOS</a></li>
-                    <li><a href="/organic/">ORGANIC</a></li>
-                    <li><a href="/contato/">FALE CONOSCO</a></li>
+                    <li><a href="../">INÍCIO</a></li>
+                    <li><a href="../quem-somos/">QUEM SOMOS</a></li>
+                    <li><a href=".">ORGANIC</a></li>
+                    <li><a href="../contato/">FALE CONOSCO</a></li>
                 </ul>
             </nav>
         </div>
@@ -75,7 +75,7 @@
                 </div>
 
                 <div class="cta-button" data-aos="fade-up" data-aos-delay="200">
-                    <a href="/contato/" class="btn">ENTRE EM CONTATO CONOSCO</a>
+                    <a href="../contato/" class="btn">ENTRE EM CONTATO CONOSCO</a>
                 </div>
             </div>
         </section>

--- a/quem-somos/index.html
+++ b/quem-somos/index.html
@@ -15,7 +15,7 @@
     <!-- A. Cabeçalho -->
     <header>
         <div class="container">
-            <a href="/" class="logo">Pro Solo</a>
+            <a href="../" class="logo">Pro Solo</a>
             <nav>
                 <button class="hamburger" id="hamburger-menu">
                     <span></span>
@@ -23,10 +23,10 @@
                     <span></span>
                 </button>
                 <ul id="nav-links">
-                    <li><a href="/">INÍCIO</a></li>
-                    <li><a href="/quem-somos/">QUEM SOMOS</a></li>
-                    <li><a href="/organic/">ORGANIC</a></li>
-                    <li><a href="/contato/">FALE CONOSCO</a></li>
+                    <li><a href="../">INÍCIO</a></li>
+                    <li><a href=".">QUEM SOMOS</a></li>
+                    <li><a href="../organic/">ORGANIC</a></li>
+                    <li><a href="../contato/">FALE CONOSCO</a></li>
                 </ul>
             </nav>
         </div>


### PR DESCRIPTION
This commit resolves the 404 errors encountered during site navigation by converting all absolute navigation links to relative paths. This ensures that navigation works correctly in all environments, including when the site is opened directly from the file system.

- The root `index.html` now links to sub-pages using `quem-somos/`, etc.
- All sub-pages now link back to the root using `../` and to other sub-pages using `../other-page/`.

This change, combined with the previous fix for asset paths, makes the entire site's linking structure relative and robust, resolving all reported issues.