### PR TITLE
feat: Replace text logo with image logo

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -101,11 +101,14 @@ header .container {
 }
 
 .logo {
-    font-family: 'Montserrat', sans-serif;
-    font-size: 24px;
-    font-weight: 700;
-    color: var(--verde-principal);
-    text-decoration: none;
+    display: inline-block; /* Garante que o link se ajuste ao tamanho da imagem */
+    vertical-align: middle; /* Alinha verticalmente com outros itens, se houver */
+}
+
+.logo img {
+    height: 40px; /* Define uma altura fixa para o logo */
+    width: auto; /* Mantém a proporção da imagem */
+    display: block; /* Remove qualquer espaço extra abaixo da imagem */
 }
 
 header nav ul {

--- a/contato/index.html
+++ b/contato/index.html
@@ -27,7 +27,7 @@
     <!-- A. Cabeçalho -->
     <header>
         <div class="container">
-            <a href="../" class="logo">Pro Solo</a>
+            <a href="../" class="logo"><img src="../assets/images/logo-prosolo.png" alt="Pro Solo Logo"></a>
             <nav>
                 <button class="hamburger" id="hamburger-menu">
                     <span></span>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <!-- A. Cabeçalho -->
     <header>
         <div class="container">
-            <a href="." class="logo">Pro Solo</a>
+            <a href="." class="logo"><img src="assets/images/logo-prosolo.png" alt="Pro Solo Logo"></a>
             <nav>
                 <button class="hamburger" id="hamburger-menu">
                     <span></span>

--- a/organic/index.html
+++ b/organic/index.html
@@ -15,7 +15,7 @@
     <!-- A. Cabeçalho -->
     <header>
         <div class="container">
-            <a href="../" class="logo">Pro Solo</a>
+            <a href="../" class="logo"><img src="../assets/images/logo-prosolo.png" alt="Pro Solo Logo"></a>
             <nav>
                 <button class="hamburger" id="hamburger-menu">
                     <span></span>

--- a/quem-somos/index.html
+++ b/quem-somos/index.html
@@ -15,7 +15,7 @@
     <!-- A. Cabeçalho -->
     <header>
         <div class="container">
-            <a href="../" class="logo">Pro Solo</a>
+            <a href="../" class="logo"><img src="../assets/images/logo-prosolo.png" alt="Pro Solo Logo"></a>
             <nav>
                 <button class="hamburger" id="hamburger-menu">
                     <span></span>


### PR DESCRIPTION
Replaces the text-based "Pro Solo" logo in the header with the image logo from `assets/images/logo-prosolo.png`.

This change is applied to all pages of the website. The CSS has been updated to style the new logo image correctly.