### PR TITLE
feat: Replace homepage video with local file

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
         <section id="inicio">
             <div class="video-background">
                 <video autoplay loop muted playsinline>
-                    <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4">
+                    <source src="assets/images/Video_Home.mp4" type="video/mp4">
                 </video>
             </div>
             <div class="overlay"></div>


### PR DESCRIPTION
Replaces the w3schools.com video on the homepage with the local video found in `assets/images/Video_Home.mp4`, as requested by the user.