### PR TITLE
feat: Add Public Sector Partnerships section to About Us page

### DIFF
--- a/quem-somos/index.html
+++ b/quem-somos/index.html
@@ -48,6 +48,19 @@
                 </div>
             </div>
         </section>
+
+        <!-- D. Seção "Parcerias" -->
+        <section id="parcerias" class="page-section" style="background-color: #f4f4f4;">
+            <div class="container">
+                <div class="quem-somos-content" style="justify-content: center; text-align: center;">
+                    <div class="text-column" data-aos="fade-up" style="flex: 0 0 80%;">
+                        <h2 style="color: var(--dourado);">Parcerias no Setor Público</h2>
+                        <p>Nossa especialização no setor público é validada pela parceria de sucesso com mais de 16 prefeituras em Minas Gerais. Compreendemos os desafios da gestão municipal, desde a necessidade de manter os espaços públicos seguros e limpos até a importância de operar em estrita conformidade com as leis ambientais.</p>
+                        <p>Por isso, oferecemos soluções técnicas e legalmente embasadas, com registros no IMA e CREA, posicionando a PRO SOLO como o parceiro estratégico ideal para garantir a eficiência, a sustentabilidade e a tranquilidade na administração da sua cidade.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
     </main>
 
     <!-- F. Rodapé -->


### PR DESCRIPTION
This commit adds a new section titled "Parcerias no Setor Público" to the "Quem Somos" (About Us) page.

The new section includes the text provided by the user, detailing the company's experience and partnerships with municipalities in Minas Gerais.

The design of the new section is consistent with the existing page layout, and the content is centered for a clean presentation after removing the initial placeholder image based on user feedback.