### PR TITLE
Fix: Adjust Quem Somos image size to match text height

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -381,7 +381,6 @@ header nav ul li a:hover::after {
 
 .home-page #quem-somos .quem-somos-content {
     display: flex;
-    align-items: center;
     gap: 60px; /* Mais respiro */
 }
 
@@ -391,8 +390,9 @@ header nav ul li a:hover::after {
 }
 
 .home-page #quem-somos .quem-somos-image img {
-    max-width: 100%;
-    height: auto;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
     border-radius: 20px; /* Bordas mais arredondadas */
     display: block;
 }


### PR DESCRIPTION
This commit adjusts the CSS for the 'Quem Somos' section on the homepage.

The image in this section was previously too large and not aligned with the height of the accompanying text. The changes ensure that the image's height dynamically matches the height of the text block next to it, creating a more balanced and visually appealing layout.