### PR TITLE
feat: Redireciona o formulário de contato para o WhatsApp

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -51,4 +51,23 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     });
+
+    // 5. WhatsApp Redirect for Contact Form
+    const contactForm = document.getElementById('contact-form');
+    if (contactForm) {
+        contactForm.addEventListener('submit', e => {
+            e.preventDefault();
+
+            const name = document.getElementById('name').value;
+            const contact = document.getElementById('contact').value;
+            const message = document.getElementById('message').value;
+
+            const companyNumber = '5531971735566';
+            const text = `Olá! Meu nome é ${name} (${contact}).\n\n${message}`;
+
+            const whatsappUrl = `https://wa.me/${companyNumber}?text=${encodeURIComponent(text)}`;
+
+            window.open(whatsappUrl, '_blank');
+        });
+    }
 });

--- a/contato/index.html
+++ b/contato/index.html
@@ -59,12 +59,14 @@
                         </ul>
                     </div>
                     <div class="contact-form" data-aos="fade-left" data-aos-delay="200">
-                        <form action="mailto:prosolominas@gmail.com" method="post" enctype="text/plain">
+                        <form id="contact-form">
                             <label for="name" class="visually-hidden">Nome</label>
                             <input type="text" id="name" name="name" placeholder="Nome" required>
+                            <label for="contact" class="visually-hidden">Contato</label>
+                            <input type="text" id="contact" name="contact" placeholder="Contato (telefone ou e-mail)" required>
                             <label for="message" class="visually-hidden">Mensagem</label>
                             <textarea id="message" name="message" placeholder="Mensagem" rows="5" required></textarea>
-                            <button type="submit" class="btn">ENVIAR</button>
+                            <button type="submit" class="btn">ENVIAR VIA WHATSAPP</button>
                         </form>
                     </div>
                 </div>


### PR DESCRIPTION
Esta alteração modifica o formulário de contato na página 'Fale Conosco' para que, ao ser enviado, abra o WhatsApp com uma mensagem pré-preenchida.

- O formulário em `contato/index.html` foi atualizado para remover a ação `mailto` e incluir um campo de 'Contato'.
- Um script foi adicionado a `assets/js/script.js` para capturar o envio do formulário, formatar os dados e construir uma URL `https://wa.me/` para redirecionar o usuário.