### PR TITLE
feat: Add new paragraph to "Quem Somos" page

### DIFF
--- a/quem-somos/index.html
+++ b/quem-somos/index.html
@@ -44,6 +44,10 @@
                         <h2>QUEM SOMOS</h2>
                         <p>A PRO SOLO é referência em capina química e orgânica, oferecendo soluções seguras, eficazes e personalizadas para eliminar ervas daninhas e plantas invasoras.</p>
                         <p>Com uma abordagem responsável, priorizamos a saúde do solo, das plantações e do meio ambiente, garantindo resultados de alto padrão para áreas urbanas, rurais e industriais. Já atendemos mais de 16 prefeituras e possuímos todos os registros necessários, incluindo IMA e CREA, para garantir um serviço de máxima qualidade e conformidade.</p>
+
+                        <h3 style="margin-top: 20px; font-weight: bold;">Serviço de Capina Química: Soluções Profissionais para Áreas Públicas e Privadas</h3>
+                        <p>A PRO SOLO oferece soluções especializadas para o controle de vegetação indesejada em áreas urbanas, rurais e industriais. Nosso trabalho atende prefeituras, órgãos públicos e clientes que buscam eficiência, segurança e respeito ao meio ambiente.</p>
+                        <p>A manutenção de áreas verdes como quintais, jardins, praças públicas e parques exige cuidados constantes para eliminar ervas daninhas e plantas invasoras. Com a proibição do uso de herbicidas tóxicos por prefeituras, o ORGANIC, nosso herbicida orgânico e ecológico, se tornou a solução ideal para esse tipo de serviço.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Adds a new section with a subheading and two paragraphs to the "Quem Somos" page, detailing the chemical weeding service offered by Pro Solo.