### PR TITLE
feat: change header color on scroll

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -89,11 +89,11 @@ body.home-page header {
     box-shadow: none;
 }
 
-/* Header com rolagem (home page) - Mantém transparente */
+/* Header com rolagem (home page) - Fica verde */
 body.home-page header.scrolled {
-    background-color: transparent;
-    box-shadow: none;
-    padding: 10px 0; /* Mantém o padding para um efeito sutil de encolhimento */
+    background-color: var(--verde-escuro);
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    padding: 10px 0;
 }
 
 header .container {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -11,9 +11,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 2. Interactive Header
     const header = document.querySelector('header');
-
     if (header) {
-        const scrollThreshold = 50;
+        let scrollThreshold = 50;
+        const heroSection = document.getElementById('inicio');
+        const isHomePage = document.body.classList.contains('home-page');
+
+        const calculateThreshold = () => {
+            if (isHomePage && heroSection) {
+                // O header muda quando o scroll passar da altura da seção hero, menos a altura do próprio header.
+                // Usamos Math.max para garantir que o threshold não seja menor que um valor mínimo (ex: 70px).
+                scrollThreshold = Math.max(70, heroSection.offsetHeight - header.offsetHeight);
+            } else {
+                scrollThreshold = 50;
+            }
+        };
+
         const updateHeader = () => {
             if (window.scrollY > scrollThreshold) {
                 header.classList.add('scrolled');
@@ -21,8 +33,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 header.classList.remove('scrolled');
             }
         };
-        window.addEventListener('scroll', updateHeader);
+
+        calculateThreshold();
         updateHeader();
+
+        window.addEventListener('scroll', updateHeader);
+        window.addEventListener('resize', () => {
+            calculateThreshold();
+            updateHeader();
+        });
     }
 
     // 3. Initialize AOS (Animate on Scroll)


### PR DESCRIPTION
This commit implements a change to the homepage header.

The header is now transparent on page load and becomes solid green when the user scrolls past the hero section. This is achieved by:
- Modifying the CSS to apply a green background and box-shadow to the header when the 'scrolled' class is present.
- Updating the JavaScript to dynamically calculate the scroll threshold based on the hero section's height, ensuring the class is applied at the correct moment.